### PR TITLE
scheduler: Fix bug in scheduling safety task

### DIFF
--- a/src/kyron/src/safety.rs
+++ b/src/kyron/src/safety.rs
@@ -46,7 +46,8 @@ pub fn ensure_safety_enabled() {
 ///
 /// # Safety
 /// This API is intended to provide a way to ensure that user can react on errors within a `task` independent  of other workers state (ie. being busy looping etc).
-/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in `SafetyWorker`.
+/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in either `SafetyWorker` or regular worker.
+/// Assumption of Use is that the task that is running on SafetyWorker never blocks.
 ///
 pub fn spawn<F, T, E>(future: F) -> JoinHandle<F::Output>
 where
@@ -64,7 +65,8 @@ where
 ///
 /// # Safety
 /// This API is intended to provide a way to ensure that user can react on errors within a `task` independent  of other workers state (ie. being busy looping etc).
-/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in `SafetyWorker`.
+/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in either `SafetyWorker` or regular worker.
+/// Assumption of Use is that the task that is running on SafetyWorker never blocks.
 ///
 pub fn spawn_from_boxed<T, E>(boxed: FutureBox<SafetyResult<T, E>>) -> JoinHandle<SafetyResult<T, E>>
 where
@@ -88,7 +90,8 @@ where
 ///
 /// # Safety
 /// This API is intended to provide a way to ensure that user can react on errors within a `task` independent  of other workers state (ie. being busy looping etc).
-/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in `SafetyWorker`.
+/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in either `SafetyWorker` or regular worker.
+/// Assumption of Use is that the task that is running on SafetyWorker never blocks.
 ///
 pub fn spawn_from_reusable<T, E>(reusable: ReusableBoxFuture<SafetyResult<T, E>>) -> JoinHandle<SafetyResult<T, E>>
 where
@@ -113,7 +116,8 @@ where
 ///
 /// # Safety
 /// This API is intended to provide a way to ensure that user can react on errors within a `task` independent  of other workers state (ie. being busy looping etc).
-/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in `SafetyWorker`.
+/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in either `SafetyWorker` or regular worker.
+/// Assumption of Use is that the task that is running on SafetyWorker never blocks.
 ///
 pub fn spawn_on_dedicated<F, T, E>(future: F, worker_id: UniqueWorkerId) -> JoinHandle<F::Output>
 where
@@ -131,7 +135,8 @@ where
 ///
 /// # Safety
 /// This API is intended to provide a way to ensure that user can react on errors within a `task` independent  of other workers state (ie. being busy looping etc).
-/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in `SafetyWorker`.
+/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in either `SafetyWorker` or regular worker.
+/// Assumption of Use is that the task that is running on SafetyWorker never blocks.
 ///
 pub fn spawn_from_boxed_on_dedicated<T, E>(
     boxed: FutureBox<SafetyResult<T, E>>,
@@ -158,7 +163,8 @@ where
 ///
 /// # Safety
 /// This API is intended to provide a way to ensure that user can react on errors within a `task` independent  of other workers state (ie. being busy looping etc).
-/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in `SafetyWorker`.
+/// This means that if the `task` (aka provided Future) will return Err(_), then the task that is awaiting on JoinHandle will be woken up in either `SafetyWorker` or regular worker.
+/// Assumption of Use is that the task that is running on SafetyWorker never blocks.
 ///
 pub fn spawn_from_reusable_on_dedicated<T, E>(
     reusable: ReusableBoxFuture<SafetyResult<T, E>>,

--- a/src/kyron/src/scheduler/context.rs
+++ b/src/kyron/src/scheduler/context.rs
@@ -542,6 +542,7 @@ pub(crate) fn ctx_get_drivers() -> Drivers {
     .unwrap()
 }
 
+#[allow(dead_code)] // Mock function is used instead of this if mock runtime feature is enabled
 ///
 /// Sets currently running `task`
 ///
@@ -559,6 +560,7 @@ pub(super) fn ctx_set_running_task(task: TaskRef) {
         });
 }
 
+#[allow(dead_code)] // Mock function is used instead of this if mock runtime feature is enabled
 ///
 /// Clears currently running `task`
 ///
@@ -574,6 +576,7 @@ pub(super) fn ctx_unset_running_task() {
         .map_err(|_| {});
 }
 
+#[allow(dead_code)] // Mock function is used instead of this if mock runtime feature is enabled
 ///
 /// Gets currently running `task id`
 ///
@@ -586,6 +589,27 @@ pub(crate) fn ctx_get_running_task_id() -> Option<TaskId> {
             .borrow()
             .as_ref()
             .map(|task| task.id())
+    })
+    .unwrap_or_else(|e| {
+        panic!("Something is really bad here, error {}!", e);
+    })
+}
+
+#[allow(dead_code)] // Mock function is used instead of this if mock runtime feature is enabled
+///
+/// Returns `true` if the running task resulted in safety error
+///
+pub(crate) fn ctx_get_task_safety_error() -> bool {
+    CTX.try_with(|ctx| {
+        // This funcation can be called from a thread outside of Kyron runtime through wake()/wake_by_ref(), so we need to check for ctx presence
+        if let Some(cx) = ctx.borrow().as_ref() {
+            cx.running_task
+                .borrow()
+                .as_ref()
+                .is_some_and(|task| task.get_task_safety_error())
+        } else {
+            false
+        }
     })
     .unwrap_or_else(|e| {
         panic!("Something is really bad here, error {}!", e);

--- a/src/kyron/src/scheduler/execution_engine.rs
+++ b/src/kyron/src/scheduler/execution_engine.rs
@@ -541,7 +541,8 @@ mod tests {
     #[test]
     #[cfg(not(miri))] // Provenance issues
     fn create_engine_with_worker_and_verify_ids() {
-        use crate::scheduler::context::{ctx_get_running_task_id, ctx_get_worker_id};
+        use crate::scheduler::context::ctx_get_worker_id;
+        use crate::testing::mock_context::ctx_get_running_task_id;
         let mut engine = ExecutionEngineBuilder::new()
             .workers(1)
             .task_queue_size(16)

--- a/src/kyron/src/scheduler/safety_waker.rs
+++ b/src/kyron/src/scheduler/safety_waker.rs
@@ -55,11 +55,9 @@ static VTABLE: RawWakerVTable = RawWakerVTable::new(clone_waker, wake, wake_by_r
 ///
 /// Waker will store internally a pointer to the ref counted Task.
 ///
-pub(crate) unsafe fn create_safety_waker(waker: Waker) -> Waker {
-    let raw_waker = RawWaker::new(waker.data(), &VTABLE);
-
-    // Forget original as we took over the ownership, so ref count
-    ::core::mem::forget(waker);
+pub(crate) fn create_safety_waker(ptr: TaskRef) -> Waker {
+    let ptr = TaskRef::into_raw(ptr); // Extracts the pointer from TaskRef not decreasing it's reference count. Since we have a clone here, ref cnt was already increased
+    let raw_waker = RawWaker::new(ptr as *const (), &VTABLE);
 
     // Convert RawWaker to Waker
     unsafe { Waker::from_raw(raw_waker) }

--- a/src/kyron/src/scheduler/task/task_context.rs
+++ b/src/kyron/src/scheduler/task/task_context.rs
@@ -11,12 +11,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // *******************************************************************************
 
+#[cfg(not(any(test, feature = "runtime-api-mock")))]
+use crate::scheduler::context::{
+    ctx_get_running_task_id, ctx_get_task_safety_error, ctx_set_running_task, ctx_unset_running_task,
+};
+#[cfg(any(test, feature = "runtime-api-mock"))]
+use crate::testing::mock_context::{
+    ctx_get_running_task_id, ctx_get_task_safety_error, ctx_set_running_task, ctx_unset_running_task,
+};
 use crate::{
     core::types::TaskId,
-    scheduler::{
-        context::{ctx_get_running_task_id, ctx_get_worker_id, ctx_set_running_task, ctx_unset_running_task},
-        workers::worker_types::WorkerId,
-    },
+    scheduler::{context::ctx_get_worker_id, workers::worker_types::WorkerId},
     TaskRef,
 };
 
@@ -32,6 +37,11 @@ impl TaskContext {
     /// Get the TaskId of the currently executing task, if any. Usage of this outside runtime causes panic.
     pub fn task_id() -> Option<TaskId> {
         ctx_get_running_task_id()
+    }
+
+    /// Check whether the running task resulted in safety error to schedule parent into safety worker
+    pub(crate) fn should_wake_task_into_safety() -> bool {
+        ctx_get_task_safety_error()
     }
 }
 

--- a/src/kyron/src/scheduler/workers/safety_worker.rs
+++ b/src/kyron/src/scheduler/workers/safety_worker.rs
@@ -24,9 +24,9 @@ use crate::{
     scheduler::{
         context::{ctx_initialize, ContextBuilder},
         driver::Drivers,
+        safety_waker::create_safety_waker,
         scheduler_mt::{AsyncScheduler, DedicatedScheduler},
         task::{async_task::TaskPollResult, task_context::TaskContextGuard},
-        waker::create_waker,
     },
     TaskRef,
 };
@@ -176,7 +176,7 @@ impl WorkerInner {
     }
 
     fn run_task(&mut self, task: TaskRef) {
-        let waker = create_waker(task.clone());
+        let waker = create_safety_waker(task.clone());
         let mut ctx = Context::from_waker(&waker);
         let _guard = TaskContextGuard::new(task.clone());
         match task.poll(&mut ctx) {

--- a/src/kyron/src/testing/mock.rs
+++ b/src/kyron/src/testing/mock.rs
@@ -16,7 +16,11 @@
 use crate::{
     core::types::{box_future, FutureBox, UniqueWorkerId},
     futures::reusable_box_future::ReusableBoxFuture,
-    scheduler::{join_handle::JoinHandle, task::async_task::TaskRef, waker::create_waker},
+    scheduler::{
+        join_handle::JoinHandle,
+        task::{async_task::TaskRef, task_context::TaskContextGuard},
+        waker::create_waker,
+    },
     testing::*,
 };
 use ::core::{cell::RefCell, future::Future, sync::atomic, task::Context};
@@ -95,7 +99,7 @@ pub mod runtime {
         while let Some(task) = dequeue_task() {
             let waker = create_waker(task.clone());
             let mut ctx = Context::from_waker(&waker);
-
+            let _guard = TaskContextGuard::new(task.clone());
             task.poll(&mut ctx);
             if !task.is_done() {
                 to_enqueue.push(task);

--- a/src/kyron/src/testing/mock_context.rs
+++ b/src/kyron/src/testing/mock_context.rs
@@ -1,0 +1,53 @@
+// *******************************************************************************
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+use crate::core::types::TaskId;
+use crate::TaskRef;
+
+// Thread-local storage to set/get running task in mock context
+use ::core::cell::RefCell;
+thread_local! {
+    static MOCK_TASK_CTX: RefCell<Option<TaskRef>> = const { RefCell::new(None) };
+}
+
+///
+/// Sets currently running `task`
+///
+pub(crate) fn ctx_set_running_task(task: TaskRef) {
+    let _ = MOCK_TASK_CTX.try_with(|ctx| ctx.replace(Some(task)));
+}
+
+///
+/// Clears currently running `task`
+///
+pub(crate) fn ctx_unset_running_task() {
+    let _ = MOCK_TASK_CTX.try_with(|ctx| ctx.replace(None));
+}
+
+///
+/// Returns `true` if the running task resulted in safety error
+///
+pub(crate) fn ctx_get_task_safety_error() -> bool {
+    MOCK_TASK_CTX
+        .try_with(|ctx| ctx.borrow().as_ref().is_some_and(|task| task.get_task_safety_error()))
+        .unwrap_or_default()
+}
+
+///
+/// Gets currently running `task id`
+///
+pub(crate) fn ctx_get_running_task_id() -> Option<TaskId> {
+    MOCK_TASK_CTX
+        .try_with(|ctx| ctx.borrow().as_ref().map(|task| task.id()))
+        .unwrap_or_default()
+}

--- a/src/kyron/src/testing/mod.rs
+++ b/src/kyron/src/testing/mod.rs
@@ -33,6 +33,8 @@ use crate::{
 
 #[cfg(any(test, feature = "runtime-api-mock"))]
 pub mod mock;
+#[cfg(any(test, feature = "runtime-api-mock"))]
+pub mod mock_context;
 
 #[derive(Default)]
 pub struct SchedulerSyncMock {

--- a/tests/test_cases/tests/runtime/worker/test_safety_worker.py
+++ b/tests/test_cases/tests/runtime/worker/test_safety_worker.py
@@ -120,7 +120,6 @@ class TestEnsureSafetyOutsideAsyncContext(CitScenario):
 # region safety worker core
 
 
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestTaskHandling(CitScenario):
     @pytest.fixture(scope="class")
     def scenario_name(self) -> str:
@@ -169,7 +168,6 @@ class TestTaskHandling(CitScenario):
         )
 
 
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestNestedTaskHandling(CitScenario):
     @pytest.fixture(scope="class")
     def scenario_name(self) -> str:
@@ -425,7 +423,6 @@ class ThreadParametersBase(CitScenario):
 
 @pytest.mark.root_required
 @pytest.mark.skipif("WSL" in platform(), reason="Not supported on WSL")
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestSafeWorkerThreadParameters(ThreadParametersBase):
     @pytest.fixture(scope="class")
     def scheduler(self) -> str:
@@ -481,7 +478,6 @@ class ThreadParametersNegativeBase(ThreadParametersBase):
 
 @pytest.mark.root_required
 @pytest.mark.skipif("WSL" in platform(), reason="Not supported on WSL")
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestSafeWorkerMissingThreadParameterScheduler(ThreadParametersNegativeBase):
     @pytest.fixture(scope="class")
     def priority(self) -> int:
@@ -502,7 +498,6 @@ class TestSafeWorkerMissingThreadParameterScheduler(ThreadParametersNegativeBase
 
 @pytest.mark.root_required
 @pytest.mark.skipif("WSL" in platform(), reason="Not supported on WSL")
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestSafeWorkerMissingThreadParameterPriority(ThreadParametersNegativeBase):
     @pytest.fixture(scope="class")
     def scheduler(self) -> str:
@@ -523,7 +518,6 @@ class TestSafeWorkerMissingThreadParameterPriority(ThreadParametersNegativeBase)
 
 @pytest.mark.root_required
 @pytest.mark.skipif("WSL" in platform(), reason="Not supported on WSL")
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestSafeWorkerMissingThreadParameters(ThreadParametersNegativeBase):
     @pytest.fixture(scope="class")
     def test_config(self) -> dict[str, Any]:
@@ -540,7 +534,6 @@ class TestSafeWorkerMissingThreadParameters(ThreadParametersNegativeBase):
 # region spawn methods
 
 
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestSpawnFromBoxed(CitScenario):
     @pytest.fixture(scope="class")
     def scenario_name(self) -> str:
@@ -569,14 +562,12 @@ class TestSpawnFromBoxed(CitScenario):
         )
 
 
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestSpawnFromReusable(TestSpawnFromBoxed):
     @pytest.fixture(scope="class")
     def scenario_name(self) -> str:
         return "runtime.worker.safety_worker.spawn_from_reusable"
 
 
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestSpawnOnDedicated(CitScenario):
     @pytest.fixture(scope="class")
     def scenario_name(self) -> str:
@@ -610,14 +601,12 @@ class TestSpawnOnDedicated(CitScenario):
         assert len(all_thread_ids) == 3, "Each task should be executed on its own thread"
 
 
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestSpawnFromBoxedOnDedicated(CitScenario):
     @pytest.fixture(scope="class")
     def scenario_name(self) -> str:
         return "runtime.worker.safety_worker.spawn_from_boxed_on_dedicated"
 
 
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/397")
 class TestSpawnFromReusableOnDedicated(CitScenario):
     @pytest.fixture(scope="class")
     def scenario_name(self) -> str:


### PR DESCRIPTION
```
Parent Task-->spwans -----------> Task-A
           -->join_all
                                  Waker Data ptr ------> Task-B (External task, different type)
                                                         Waker Data ptr ----------------------------------> Parent Task
```
For the above scenario with safety worker enabled in runtime, after polling of Task-A which return error, it is detected as safety error and a `safety waker` is created from normal waker and `wake()` function is called. In the wake function, the `waker data ptr` is typecasted as (parent) task and further try to clone. But, there is no valid pointer in the task vtable for clone() and it results in segmentation fault.

As fix, a safety_error flag in TaskHeader and thread local schedule_safety flag are set instead of creating safety waker. When the wake function is called, it goes through Task-B and then our wake() function is executed. In this wake(), the schedule_safety flag is checked and the task is scheduled on either safety or normal worker.

In case if task is completed prior to setting JoinHandle waker, then the safety_error flag is checked in JoinHandle.poll function to reschedule the task into safety worker.


<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [x] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #18, #20, #39  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
