### PR TITLE
bazel: remove scenarios override

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,12 +49,6 @@ bazel_dep(name = "score_test_scenarios", version = "0.3.1", dev_dependency = Tru
 
 # Overrides
 git_override(
-    module_name = "score_test_scenarios",
-    commit = "2367017e92a65cf4dd2cebeee6d6db3b4d6a1447",
-    remote = "https://github.com/qorix-group/testing_tools.git",
-)
-
-git_override(
     module_name = "score_virtualization",
     commit = "99d3f153c43796b67a63e82aad1ede6a881aa6af",
     remote = "https://github.com/qorix-group/score_virtualization.git",


### PR DESCRIPTION
use release from bazel registry

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
