### PR TITLE
scheduler: use wakers efficiently

### DIFF
--- a/src/kyron/src/scheduler/safety_waker.rs
+++ b/src/kyron/src/scheduler/safety_waker.rs
@@ -31,15 +31,13 @@ fn wake(data: *const ()) {
     let task_ref = unsafe { TaskRef::from_raw(task_header_ptr) };
 
     task_ref.schedule_safety();
-
-    drop(task_ref); // wake uses move semantic, so we are owner of data now, so we need to cleanup
 }
 
 fn wake_by_ref(data: *const ()) {
     let task_header_ptr = data as *const TaskHeader;
     let task_ref = unsafe { TaskRef::from_raw(task_header_ptr) };
 
-    task_ref.schedule_safety();
+    task_ref.schedule_safety_by_ref();
 
     ::core::mem::forget(task_ref); // don't touch refcount from our data since this is done by drop_waker
 }

--- a/src/kyron/src/scheduler/task/async_task.rs
+++ b/src/kyron/src/scheduler/task/async_task.rs
@@ -543,20 +543,38 @@ impl TaskRef {
     }
 
     ///
-    /// Proxy to `AsyncTask<T>::schedule`
+    /// Proxy to `AsyncTask<T>::schedule_by_ref`
     ///
-    pub(crate) fn schedule(&self) {
+    pub(crate) fn schedule_by_ref(&self) {
         unsafe {
             (self.header.as_ref().vtable.schedule)(self.header, self.clone());
         }
     }
 
     ///
+    /// Proxy to `AsyncTask<T>::schedule`
+    ///
+    pub(crate) fn schedule(self) {
+        unsafe {
+            (self.header.as_ref().vtable.schedule)(self.header, self);
+        }
+    }
+
+    ///
     /// Proxy to `AsyncTask<T>::schedule_safety`
     ///
-    pub(crate) fn schedule_safety(&self) {
+    pub(crate) fn schedule_safety_by_ref(&self) {
         unsafe {
             (self.header.as_ref().vtable.schedule_safety)(self.header, self.clone());
+        }
+    }
+
+    ///
+    /// Proxy to `AsyncTask<T>::schedule_safety`
+    ///
+    pub(crate) fn schedule_safety(self) {
+        unsafe {
+            (self.header.as_ref().vtable.schedule_safety)(self.header, self);
         }
     }
 

--- a/src/kyron/src/scheduler/waker.rs
+++ b/src/kyron/src/scheduler/waker.rs
@@ -33,15 +33,13 @@ fn wake(data: *const ()) {
     let task_ref = unsafe { TaskRef::from_raw(task_header_ptr) };
 
     task_ref.schedule();
-
-    drop(task_ref); // wake uses move semantic, so we are owner of data now, so we need to cleanup
 }
 
 fn wake_by_ref(data: *const ()) {
     let task_header_ptr = data as *const TaskHeader;
     let task_ref = unsafe { TaskRef::from_raw(task_header_ptr) };
 
-    task_ref.schedule();
+    task_ref.schedule_by_ref();
 
     ::core::mem::forget(task_ref); // don't touch refcount from our data since this is done by drop_waker
 }


### PR DESCRIPTION
Make use of moved waker value instead always
cloning it. This bring 4-10% performance increase
depending on OS because wake call is fundamental
and is used very often.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #8 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
