### PR TITLE
cicd: clean old doc pages

### DIFF
--- a/.github/workflows/docs_cleanup.yml
+++ b/.github/workflows/docs_cleanup.yml
@@ -1,0 +1,29 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Documentation Cleanup
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs every day at midnight UTC
+
+jobs:
+  docs-cleanup:
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
remove documentation of old PRs

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
