### PR TITLE
worker: Expose safety worker queue size config

### DIFF
--- a/src/kyron/src/scheduler/workers/safety_worker.rs
+++ b/src/kyron/src/scheduler/workers/safety_worker.rs
@@ -38,8 +38,6 @@ use super::{spawn_thread, worker_types::WorkerId, ThreadParameters};
 ///
 const LOCAL_STORAGE_SIZE_REDUCTION: usize = 8;
 
-const SAFETY_QUEUE_SIZE: usize = 64; // For now hardcoded
-
 pub(crate) struct SafetyWorker {
     thread_handle: Option<Thread>,
     id: WorkerId,
@@ -49,11 +47,11 @@ pub(crate) struct SafetyWorker {
 }
 
 impl SafetyWorker {
-    pub(crate) fn new(id: WorkerId, thread_params: ThreadParameters) -> Self {
+    pub(crate) fn new(id: WorkerId, thread_params: ThreadParameters, safety_queue_size: u32) -> Self {
         SafetyWorker {
             id,
             thread_handle: None,
-            queue: Arc::new(TriggerQueue::new(SAFETY_QUEUE_SIZE)),
+            queue: Arc::new(TriggerQueue::new(safety_queue_size as usize)),
             stop_signal: Arc::new(FoundationAtomicBool::new(false)),
             thread_params,
         }

--- a/tests/test_cases/tests/runtime/worker/test_safety_worker.py
+++ b/tests/test_cases/tests/runtime/worker/test_safety_worker.py
@@ -310,7 +310,6 @@ class TestQueuedSafetyWorkerTasks(CitScenario):
         assert len(failing_tasks) == task_count
 
 
-@pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/396")
 class TestSafeWorkerHeavyLoad(CitScenario):
     @pytest.fixture(scope="class")
     def scenario_name(self) -> str:
@@ -331,6 +330,7 @@ class TestSafeWorkerHeavyLoad(CitScenario):
                 "task_queue_size": 2048,
                 "workers": 4,
                 "safety_worker": {},
+                "safety_worker_task_queue_size": 512,
             },
             "test": {
                 "successful_tasks": successful_task_count,

--- a/tests/test_scenarios/rust/src/internals/runtime_helper.rs
+++ b/tests/test_scenarios/rust/src/internals/runtime_helper.rs
@@ -47,6 +47,7 @@ pub struct DedicatedWorkerConfig {
 pub struct ExecEngineConfig {
     pub task_queue_size: u32,
     pub workers: usize,
+    pub safety_worker_task_queue_size: Option<u32>,
     #[serde(flatten)]
     pub thread_parameters: ThreadParameters,
     pub dedicated_workers: Option<Vec<DedicatedWorkerConfig>>,
@@ -135,6 +136,9 @@ impl Runtime {
             if let Some(safety_worker) = &exec_engine.safety_worker {
                 let safety_worker_thread_params = self.set_thread_params(safety_worker);
                 exec_engine_builder = exec_engine_builder.enable_safety_worker(safety_worker_thread_params);
+                if let Some(queue_size) = exec_engine.safety_worker_task_queue_size {
+                    exec_engine_builder = exec_engine_builder.safety_worker_task_queue_size(queue_size);
+                }
             }
 
             let (builder, _) = async_rt_builder.with_engine(exec_engine_builder);


### PR DESCRIPTION
Expose safety worker task queue size configuration to user.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #19  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
