### PR TITLE
net: Fix ttl range

### DIFF
--- a/src/kyron/src/mio/net/tcp_listener.rs
+++ b/src/kyron/src/mio/net/tcp_listener.rs
@@ -59,8 +59,8 @@ impl<T: IoSelector> TcpListenerBridge<T> {
         self.inner.as_inner().ttl()
     }
 
-    pub fn set_ttl(&self, ttl: u32) -> IoResult<()> {
-        self.inner.as_inner().set_ttl(ttl)
+    pub fn set_ttl(&self, ttl: u8) -> IoResult<()> {
+        self.inner.as_inner().set_ttl(ttl as u32)
     }
 }
 

--- a/src/kyron/src/mio/net/tcp_stream.rs
+++ b/src/kyron/src/mio/net/tcp_stream.rs
@@ -73,8 +73,8 @@ impl<T: IoSelector> TcpStreamBridge<T> {
         self.inner.as_inner().ttl()
     }
 
-    pub fn set_ttl(&self, ttl: u32) -> IoResult<()> {
-        self.inner.as_inner().set_ttl(ttl)
+    pub fn set_ttl(&self, ttl: u8) -> IoResult<()> {
+        self.inner.as_inner().set_ttl(ttl as u32)
     }
 }
 

--- a/src/kyron/src/mio/net/udp.rs
+++ b/src/kyron/src/mio/net/udp.rs
@@ -75,8 +75,8 @@ impl<T: IoSelector> UdpSocketBridge<T> {
         self.inner.as_inner().ttl()
     }
 
-    pub fn set_ttl(&self, ttl: u32) -> IoResult<()> {
-        self.inner.as_inner().set_ttl(ttl)
+    pub fn set_ttl(&self, ttl: u8) -> IoResult<()> {
+        self.inner.as_inner().set_ttl(ttl as u32)
     }
 
     pub fn local_addr(&self) -> IoResult<SocketAddr> {

--- a/src/kyron/src/net/tcp_listener.rs
+++ b/src/kyron/src/net/tcp_listener.rs
@@ -74,7 +74,7 @@ impl TcpListener {
 
     /// Sets the value for the IP_TTL option on this socket.
     /// This value sets the time-to-live field that is used in every packet sent from this socket.
-    pub fn set_ttl(&self, ttl: u32) -> NetResult<()> {
+    pub fn set_ttl(&self, ttl: u8) -> NetResult<()> {
         self.listener.set_ttl(ttl)
     }
 }

--- a/src/kyron/src/net/tcp_stream.rs
+++ b/src/kyron/src/net/tcp_stream.rs
@@ -69,7 +69,7 @@ impl TcpStream {
 
     /// Sets the value for the IP_TTL option on this socket.
     /// This value sets the time-to-live field that is used in every packet sent from this socket.
-    pub fn set_ttl(&self, ttl: u32) -> NetResult<()> {
+    pub fn set_ttl(&self, ttl: u8) -> NetResult<()> {
         self.stream.set_ttl(ttl)
     }
 

--- a/src/kyron/src/net/udp_socket.rs
+++ b/src/kyron/src/net/udp_socket.rs
@@ -124,7 +124,7 @@ impl UdpSocket {
 
     /// Sets the value for the IP_TTL option on this socket.
     /// This value sets the time-to-live field that is used in every packet sent from this socket.
-    pub fn set_ttl(&self, ttl: u32) -> NetResult<()> {
+    pub fn set_ttl(&self, ttl: u8) -> NetResult<()> {
         self.socket.set_ttl(ttl)
     }
 }

--- a/tests/test_cases/tests/runtime/net/tcp/test_tcp_listener.py
+++ b/tests/test_cases/tests/runtime/net/tcp/test_tcp_listener.py
@@ -168,15 +168,9 @@ class TestTTL_Valid(TestTTL):
 
 
 class TestTTL_Invalid(TestTTL):
-    @pytest.fixture(scope="class", params=[0, 256, 257, 2**16, 2**32 - 1])
+    @pytest.fixture(scope="class", params=[0])
     def ttl(self, request: pytest.FixtureRequest) -> int | None:
-        value = request.param
-        if value == 2**32 - 1:
-            pytest.xfail(
-                reason="Max u32 value sets TTL to default - https://github.com/qorix-group/inc_orchestrator_internal/issues/327"
-            )
-
-        return value
+        return request.param
 
     def capture_stderr(self) -> bool:
         return True

--- a/tests/test_cases/tests/runtime/net/tcp/test_tcp_stream.py
+++ b/tests/test_cases/tests/runtime/net/tcp/test_tcp_stream.py
@@ -239,15 +239,9 @@ class TestTTL_Valid(TestTTL):
 
 
 class TestTTL_Invalid(TestTTL):
-    @pytest.fixture(scope="class", params=[0, 256, 257, 2**16, 2**32 - 1])
+    @pytest.fixture(scope="class", params=[0])
     def ttl(self, request: pytest.FixtureRequest) -> int | None:
-        value = request.param
-        if value == 2**32 - 1:
-            pytest.xfail(
-                reason="Max u32 value sets TTL to default - https://github.com/qorix-group/inc_orchestrator_internal/issues/327"
-            )
-
-        return value
+        return request.param
 
     def capture_stderr(self) -> bool:
         return True

--- a/tests/test_cases/tests/runtime/net/udp/test_udp_server.py
+++ b/tests/test_cases/tests/runtime/net/udp/test_udp_server.py
@@ -149,16 +149,7 @@ class TestSetInvalidTTL(TestDefaultTTL):
 
     @pytest.fixture(
         scope="class",
-        params=[
-            0,
-            256,
-            pytest.param(
-                2**32 - 1,
-                marks=pytest.mark.xfail(
-                    reason="Max u32 value sets TTL to default - https://github.com/qorix-group/inc_orchestrator_internal/issues/327",
-                ),
-            ),
-        ],
+        params=[0],
     )
     def ttl(self, request: pytest.FixtureRequest) -> int | None:
         return request.param

--- a/tests/test_scenarios/rust/src/internals/net_helper.rs
+++ b/tests/test_scenarios/rust/src/internals/net_helper.rs
@@ -23,7 +23,7 @@ where
 pub struct ConnectionParameters {
     #[serde(flatten, deserialize_with = "deserialize_socket_addr")]
     address: SocketAddr,
-    ttl: Option<u32>,
+    ttl: Option<u8>,
 }
 
 impl ConnectionParameters {


### PR DESCRIPTION
Updated code to correct valid ttl (Time To Live) range.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #14  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
