### PR TITLE
cicd: update secrets usage

### DIFF
--- a/.github/workflows/cargo_required.yml
+++ b/.github/workflows/cargo_required.yml
@@ -15,7 +15,7 @@ name: cargo build, test, coverage and miri report
 on:
   push:
     branches: [main, development]
-  pull_request:
+  pull_request_target:
     branches: [main, development]
     types: [opened, ready_for_review, reopened, synchronize]
 
@@ -35,6 +35,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Rust Build Environment
         uses: ./.github/actions/setup-rust-build

--- a/.github/workflows/component_integration_tests.yml
+++ b/.github/workflows/component_integration_tests.yml
@@ -15,7 +15,7 @@ name: Component Integration Tests
 on:
   push:
     branches: [main, development]
-  pull_request:
+  pull_request_target:
     branches: [main, development]
     types: [opened, ready_for_review, reopened, synchronize]
   schedule:
@@ -36,6 +36,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Rust Build Environment
         uses: ./.github/actions/setup-rust-build

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -17,8 +17,6 @@ on:
     types: [opened, reopened, synchronize]
   merge_group:
     types: [checks_requested]
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   copyright-check:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,8 +18,7 @@ on:
     types: [opened, reopened, synchronize]
   merge_group:
     types: [checks_requested]
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   formatting-check:
     uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@main

--- a/.github/workflows/lint_fmt_clippy.yml
+++ b/.github/workflows/lint_fmt_clippy.yml
@@ -17,9 +17,6 @@ on:
     branches: [main, development]
     types: [opened, ready_for_review, reopened, synchronize]
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   lint-fmt-clippy:
     timeout-minutes: 6 # 6 minutes is the maximum allowed for a cold run


### PR DESCRIPTION
- remove unused secrets from workflows
- protect secrets with `pull_request_target` trigger

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
