### PR TITLE
runtime: Add TaskContext to get ids of task, engine and worker

### DIFF
--- a/src/kyron/examples/safety_task.rs
+++ b/src/kyron/examples/safety_task.rs
@@ -1,0 +1,93 @@
+//
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use kyron::prelude::*;
+use kyron::safety;
+use kyron::scheduler::task::task_context::TaskContext;
+use kyron::spawn_on_dedicated;
+use kyron_foundation::prelude::*;
+
+async fn failing_safety_task() -> Result<(), String> {
+    info!(
+        "Worker-N: failing_safety_task. Worker ID: {:?}, Task ID: {:?}",
+        TaskContext::worker_id(),
+        TaskContext::task_id().unwrap()
+    );
+    Err("Intentional failure".to_string())
+}
+
+async fn passing_safety_task() -> Result<(), String> {
+    info!(
+        "Worker-N: passing_safety_task. Worker ID: {:?}, Task ID: {:?}",
+        TaskContext::worker_id(),
+        TaskContext::task_id().unwrap()
+    );
+    Ok(())
+}
+
+async fn passing_non_safety_task() -> Result<(), String> {
+    info!(
+        "Dedicated worker (dw1): passing_non_safety_task. Worker ID: {:?}, Task ID: {:?}",
+        TaskContext::worker_id(),
+        TaskContext::task_id().unwrap()
+    );
+    Ok(())
+}
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_target(false) // Optional: Remove module path
+        .with_max_level(Level::DEBUG)
+        .with_thread_ids(true)
+        .with_thread_names(true)
+        .init();
+
+    // Create runtime
+    let (builder, _engine_id) = kyron::runtime::RuntimeBuilder::new().with_engine(
+        ExecutionEngineBuilder::new()
+            .task_queue_size(256)
+            .enable_safety_worker(ThreadParameters::default())
+            .with_dedicated_worker("dw1".into(), ThreadParameters::default())
+            .workers(2),
+    );
+
+    let mut runtime = builder.build().unwrap();
+    // Put programs into runtime and run them
+    runtime.block_on(async move {
+        info!(
+            "Parent task. Worker ID: {:?}, Task Id: {:?}",
+            TaskContext::worker_id(),
+            TaskContext::task_id().unwrap()
+        );
+        let handle1 = safety::spawn(failing_safety_task());
+        let handle2 = safety::spawn(passing_safety_task());
+        let handle3 = spawn_on_dedicated(passing_non_safety_task(), "dw1".into());
+
+        info!("=============================== Spawned all tasks ===============================");
+
+        let _ = handle1.await;
+        info!("Since safety task fails, safety worker may execute parent task from this statement onwards.");
+
+        info!(
+            "Parent task. Worker ID: {:?}, Task Id: {:?}",
+            TaskContext::worker_id(),
+            TaskContext::task_id().unwrap()
+        );
+        let _ = handle2.await;
+        let _ = handle3.await;
+
+        info!("Program finished running.");
+    });
+
+    info!("Exit.");
+}

--- a/src/kyron/src/runtime/runtime_impl.rs
+++ b/src/kyron/src/runtime/runtime_impl.rs
@@ -49,6 +49,7 @@ impl RuntimeBuilder {
     ///
     pub fn with_engine(mut self, builder: ExecutionEngineBuilder) -> (Self, usize) {
         let id = self.next_id;
+        let builder = builder.set_engine_id(id as u8);
         self.engine_builders.push(builder);
         self.next_id += 1;
         (self, id)

--- a/src/kyron/src/scheduler/join_handle.rs
+++ b/src/kyron/src/scheduler/join_handle.rs
@@ -135,7 +135,8 @@ mod tests {
 
         {
             // Data is present after first poll of join handle
-            let task = ArcInternal::new(AsyncTask::new(box_future(test_function::<u32>()), 1, scheduler.clone()));
+            let worker_id = create_mock_worker_id(0, 1);
+            let task = ArcInternal::new(AsyncTask::new(box_future(test_function::<u32>()), &worker_id, scheduler.clone()));
 
             let handle = JoinHandle::<u32>::new(TaskRef::new(task.clone()));
 
@@ -157,7 +158,8 @@ mod tests {
 
         {
             // Data is present before first poll of join handle
-            let task = ArcInternal::new(AsyncTask::new(box_future(test_function_ret::<u32>(1234)), 1, scheduler.clone()));
+            let worker_id = create_mock_worker_id(0, 1);
+            let task = ArcInternal::new(AsyncTask::new(box_future(test_function_ret::<u32>(1234)), &worker_id, scheduler.clone()));
 
             let handle = JoinHandle::<u32>::new(TaskRef::new(task.clone()));
 
@@ -179,7 +181,8 @@ mod tests {
         let scheduler = create_mock_scheduler();
 
         {
-            let task = ArcInternal::new(AsyncTask::new(box_future(test_function_ret::<u32>(1234)), 1, scheduler.clone()));
+            let worker_id = create_mock_worker_id(0, 1);
+            let task = ArcInternal::new(AsyncTask::new(box_future(test_function_ret::<u32>(1234)), &worker_id, scheduler.clone()));
 
             let handle = JoinHandle::<u32>::new(TaskRef::new(task.clone()));
 
@@ -195,7 +198,8 @@ mod tests {
         }
 
         {
-            let task = ArcInternal::new(AsyncTask::new(box_future(test_function::<u32>()), 1, scheduler.clone()));
+            let worker_id = create_mock_worker_id(0, 1);
+            let task = ArcInternal::new(AsyncTask::new(box_future(test_function::<u32>()), &worker_id, scheduler.clone()));
             let handle = JoinHandle::<u32>::new(TaskRef::new(task.clone()));
             let mut poller = TestingFuturePoller::new(handle);
 
@@ -211,7 +215,8 @@ mod tests {
 
         {
             // Data is present before first poll of join handle
-            let task = ArcInternal::new(AsyncTask::new(box_future(test_function::<u32>()), 1, scheduler.clone()));
+            let worker_id = create_mock_worker_id(0, 1);
+            let task = ArcInternal::new(AsyncTask::new(box_future(test_function::<u32>()), &worker_id, scheduler.clone()));
 
             let handle = JoinHandle::<u32>::new(TaskRef::new(task.clone()));
 
@@ -236,7 +241,8 @@ mod tests {
 
         {
             // Data is present before first poll of join handle
-            let task = ArcInternal::new(AsyncTask::new(box_future(test_function::<u32>()), 1, scheduler.clone()));
+            let worker_id = create_mock_worker_id(0, 1);
+            let task = ArcInternal::new(AsyncTask::new(box_future(test_function::<u32>()), &worker_id, scheduler.clone()));
 
             let handle = JoinHandle::<u32>::new(TaskRef::new(task.clone()));
 
@@ -265,6 +271,7 @@ mod tests {
 
     use crate::{
         core::types::{box_future, ArcInternal},
+        scheduler::workers::worker_types::{WorkerId, WorkerType},
         AsyncTask,
     };
 
@@ -284,7 +291,8 @@ mod tests {
 
             {
                 // Data is present after first poll of join handle
-                let task = ArcInternal::new(AsyncTask::new(box_future(test_function_ret::<u32>(1234)), 1, scheduler.clone()));
+                let worker_id = create_mock_worker_id(0, 1);
+                let task = ArcInternal::new(AsyncTask::new(box_future(test_function_ret::<u32>(1234)), &worker_id, scheduler.clone()));
 
                 let handle = JoinHandle::<u32>::new(TaskRef::new(task.clone()));
 
@@ -333,7 +341,8 @@ mod tests {
 
             {
                 // Data is present after first poll of join handle
-                let task = ArcInternal::new(AsyncTask::new(box_future(test_function_ret::<u32>(1234)), 1, scheduler.clone()));
+                let worker_id = create_mock_worker_id(0, 1);
+                let task = ArcInternal::new(AsyncTask::new(box_future(test_function_ret::<u32>(1234)), &worker_id, scheduler.clone()));
 
                 let join_handle = JoinHandle::<u32>::new(TaskRef::new(task.clone()));
 

--- a/src/kyron/src/scheduler/task/mod.rs
+++ b/src/kyron/src/scheduler/task/mod.rs
@@ -12,4 +12,5 @@
 //
 
 pub mod async_task;
+pub mod task_context;
 pub mod task_state;

--- a/src/kyron/src/scheduler/task/task_context.rs
+++ b/src/kyron/src/scheduler/task/task_context.rs
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::{
+    core::types::TaskId,
+    scheduler::{
+        context::{ctx_get_running_task_id, ctx_get_worker_id, ctx_set_running_task, ctx_unset_running_task},
+        workers::worker_types::WorkerId,
+    },
+    TaskRef,
+};
+
+/// Provides access to context information about the currently executing task.
+pub struct TaskContext {}
+
+impl TaskContext {
+    /// Get the worker id of the currently executing task. Usage of this outside runtime causes panic.
+    pub fn worker_id() -> WorkerId {
+        ctx_get_worker_id()
+    }
+
+    /// Get the TaskId of the currently executing task, if any. Usage of this outside runtime causes panic.
+    pub fn task_id() -> Option<TaskId> {
+        ctx_get_running_task_id()
+    }
+}
+
+/// A guard that sets the task on creation and unsets it on drop.
+pub(crate) struct TaskContextGuard {}
+
+impl TaskContextGuard {
+    /// Sets the given task for the current context.
+    pub(crate) fn new(task: TaskRef) -> Self {
+        ctx_set_running_task(task);
+        Self {}
+    }
+}
+
+impl Drop for TaskContextGuard {
+    fn drop(&mut self) {
+        ctx_unset_running_task();
+    }
+}

--- a/src/kyron/src/scheduler/workers/dedicated_worker.rs
+++ b/src/kyron/src/scheduler/workers/dedicated_worker.rs
@@ -25,7 +25,7 @@ use crate::{
         context::{ctx_initialize, ContextBuilder},
         driver::Drivers,
         scheduler_mt::{AsyncScheduler, DedicatedScheduler},
-        task::async_task::TaskPollResult,
+        task::{async_task::TaskPollResult, task_context::TaskContextGuard},
         waker::create_waker,
         workers::{spawn_thread, Thread, ThreadParameters},
     },
@@ -181,6 +181,7 @@ impl WorkerInner {
     fn run_task(&mut self, task: TaskRef) {
         let waker = create_waker(task.clone());
         let mut ctx = Context::from_waker(&waker);
+        let _guard = TaskContextGuard::new(task.clone());
         match task.poll(&mut ctx) {
             TaskPollResult::Done => {
                 // Literally nothing to do ;)

--- a/src/kyron/src/scheduler/workers/safety_worker.rs
+++ b/src/kyron/src/scheduler/workers/safety_worker.rs
@@ -24,7 +24,7 @@ use crate::{
         context::{ctx_initialize, ContextBuilder},
         driver::Drivers,
         scheduler_mt::{AsyncScheduler, DedicatedScheduler},
-        task::async_task::TaskPollResult,
+        task::{async_task::TaskPollResult, task_context::TaskContextGuard},
         waker::create_waker,
     },
     TaskRef,
@@ -170,6 +170,7 @@ impl WorkerInner {
     fn run_task(&mut self, task: TaskRef) {
         let waker = create_waker(task.clone());
         let mut ctx = Context::from_waker(&waker);
+        let _guard = TaskContextGuard::new(task.clone());
         match task.poll(&mut ctx) {
             TaskPollResult::Done => {
                 // Literally nothing to do ;)

--- a/src/kyron/src/scheduler/workers/worker_types.rs
+++ b/src/kyron/src/scheduler/workers/worker_types.rs
@@ -36,7 +36,7 @@ pub(in super::super) const WORKER_STATE_EXECUTING: u8 = 0b00000011;
 pub(in super::super) const WORKER_STATE_SHUTTINGDOWN: u8 = 0b00000100;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub(crate) struct WorkerId {
+pub struct WorkerId {
     unique_id: UniqueWorkerId,
     engine_id: u8,   // in which engine worker is working
     worker_id: u8,   // whats the worker id in this engine
@@ -44,7 +44,7 @@ pub(crate) struct WorkerId {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub(crate) enum WorkerType {
+pub enum WorkerType {
     Async,
     Dedicated,
 }
@@ -60,21 +60,19 @@ impl WorkerId {
     }
 
     // Getters for all fields
-    pub(crate) fn unique_id(&self) -> UniqueWorkerId {
+    pub fn unique_id(&self) -> UniqueWorkerId {
         self.unique_id
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn engine_id(&self) -> u8 {
+    pub fn engine_id(&self) -> u8 {
         self.engine_id
     }
 
-    pub(crate) fn worker_id(&self) -> u8 {
+    pub fn worker_id(&self) -> u8 {
         self.worker_id
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn typ(&self) -> WorkerType {
+    pub fn typ(&self) -> WorkerType {
         self.typ
     }
 }

--- a/src/kyron/src/testing/mock.rs
+++ b/src/kyron/src/testing/mock.rs
@@ -193,8 +193,8 @@ where
             let mut instance = instance.borrow_mut();
 
             let runtime = instance.as_mut().expect("Runtime mock instance is not initialized. Did you call `init`?");
-
-            let task = Arc::new(AsyncTask::new(boxed, 0, runtime.sched.clone()));
+            let worker_id = create_mock_worker_id(0, 0);
+            let task = Arc::new(AsyncTask::new(boxed, &worker_id, runtime.sched.clone()));
             let task_ref = TaskRef::new(task);
             runtime.tasks.push_back(task_ref.clone());
             JoinHandle::new(task_ref)
@@ -216,8 +216,8 @@ where
             let mut instance = instance.borrow_mut();
 
             let runtime = instance.as_mut().expect("Runtime mock instance is not initialized. Did you call `init`?");
-
-            let task = Arc::new(AsyncTask::new(reusable.into_pin(), 0, runtime.sched.clone()));
+            let worker_id = create_mock_worker_id(0, 0);
+            let task = Arc::new(AsyncTask::new(reusable.into_pin(), &worker_id, runtime.sched.clone()));
             let task_ref = TaskRef::new(task);
             runtime.tasks.push_back(task_ref.clone());
             JoinHandle::new(task_ref)
@@ -252,8 +252,8 @@ where
             let mut instance = instance.borrow_mut();
 
             let runtime = instance.as_mut().expect("Runtime mock instance is not initialized. Did you call `init`?");
-
-            let task = Arc::new(AsyncTask::new(boxed, 0, runtime.sched.clone()));
+            let worker_id = create_mock_worker_id(0, 0);
+            let task = Arc::new(AsyncTask::new(boxed, &worker_id, runtime.sched.clone()));
             let task_ref = TaskRef::new(task);
             runtime.tasks.push_back(task_ref.clone());
             JoinHandle::new(task_ref)
@@ -275,8 +275,8 @@ where
             let mut instance = instance.borrow_mut();
 
             let runtime = instance.as_mut().expect("Runtime mock instance is not initialized. Did you call `init`?");
-
-            let task = Arc::new(AsyncTask::new(reusable.into_pin(), 0, runtime.sched.clone()));
+            let worker_id = create_mock_worker_id(0, 0);
+            let task = Arc::new(AsyncTask::new(reusable.into_pin(), &worker_id, runtime.sched.clone()));
             let task_ref = TaskRef::new(task);
             runtime.tasks.push_back(task_ref.clone());
             JoinHandle::new(task_ref)
@@ -322,8 +322,8 @@ pub mod safety {
                 let mut instance = instance.borrow_mut();
 
                 let runtime = instance.as_mut().expect("Runtime mock instance is not initialized. Did you call `init`?");
-
-                let task = Arc::new(AsyncTask::new_safety(true, boxed, 0, runtime.sched.clone()));
+                let worker_id = create_mock_worker_id(0, 0);
+                let task = Arc::new(AsyncTask::new_safety(true, boxed, &worker_id, runtime.sched.clone()));
                 let task_ref = TaskRef::new(task);
                 runtime.tasks.push_back(task_ref.clone());
                 JoinHandle::new(task_ref)
@@ -343,8 +343,8 @@ pub mod safety {
                 let mut instance = instance.borrow_mut();
 
                 let runtime = instance.as_mut().expect("Runtime mock instance is not initialized. Did you call `init`?");
-
-                let task = Arc::new(AsyncTask::new_safety(true, reusable.into_pin(), 0, runtime.sched.clone()));
+                let worker_id = create_mock_worker_id(0, 0);
+                let task = Arc::new(AsyncTask::new_safety(true, reusable.into_pin(), &worker_id, runtime.sched.clone()));
                 let task_ref = TaskRef::new(task);
                 runtime.tasks.push_back(task_ref.clone());
                 JoinHandle::new(task_ref)
@@ -375,8 +375,8 @@ pub mod safety {
                 let mut instance = instance.borrow_mut();
 
                 let runtime = instance.as_mut().expect("Runtime mock instance is not initialized. Did you call `init`?");
-
-                let task = Arc::new(AsyncTask::new_safety(true, boxed, 0, runtime.sched.clone()));
+                let worker_id = create_mock_worker_id(0, 0);
+                let task = Arc::new(AsyncTask::new_safety(true, boxed, &worker_id, runtime.sched.clone()));
                 let task_ref = TaskRef::new(task);
                 runtime.tasks.push_back(task_ref.clone());
                 JoinHandle::new(task_ref)
@@ -399,8 +399,8 @@ pub mod safety {
                 let mut instance = instance.borrow_mut();
 
                 let runtime = instance.as_mut().expect("Runtime mock instance is not initialized. Did you call `init`?");
-
-                let task = Arc::new(AsyncTask::new_safety(true, reusable.into_pin(), 0, runtime.sched.clone()));
+                let worker_id = create_mock_worker_id(0, 0);
+                let task = Arc::new(AsyncTask::new_safety(true, reusable.into_pin(), &worker_id, runtime.sched.clone()));
                 let task_ref = TaskRef::new(task);
                 runtime.tasks.push_back(task_ref.clone());
                 JoinHandle::new(task_ref)


### PR DESCRIPTION
Added TaskContext to get ids of task, engine and worker of currently executing task.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [x] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #55  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
