### PR TITLE
bazel: fix visibility of examples

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -13,19 +13,23 @@
 alias(
     name = "select",
     actual = "//src/kyron:select",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "main_macro",
     actual = "//src/kyron:main_macro",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "mpmc",
     actual = "//src/kyron:mpmc",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "safety_task",
     actual = "//src/kyron:safety_task",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
make them public for reference_integration

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes https://github.com/eclipse-score/reference_integration/issues/139 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
