### PR TITLE
chore(ci): pin cicd-workflows reusable workflows to commit SHA

### DIFF
--- a/.github/workflows/build_qnx8.yml
+++ b/.github/workflows/build_qnx8.yml
@@ -19,7 +19,7 @@ on:
     types: [checks_requested]
 jobs:
   qnx-build:
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/bzlmod-lock.yml
+++ b/.github/workflows/bzlmod-lock.yml
@@ -21,6 +21,6 @@ on:
       - main
 jobs:
   bzlmod-lock:
-    uses: eclipse-score/cicd-workflows/.github/workflows/bzlmod-lock-check.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/bzlmod-lock-check.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     with:
       working-directory: .

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -22,6 +22,6 @@ env:
 
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     with:
       bazel-target: "run --lockfile_mode=error //:copyright.check"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/docs_cleanup.yml
+++ b/.github/workflows/docs_cleanup.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,6 +22,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     with:
       bazel-target: "test --lockfile_mode=error //:format.check" # optional, this is the default

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   license-check:
     if: ${{ github.repository == 'eclipse-score/kyron' }}
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     with:
       repo-url: "${{ github.server_url }}/${{ github.repository }}"
       bazel-target: "run --lockfile_mode=error //:license-check"


### PR DESCRIPTION
This PR is part of a large-scale CI refactoring across all S-CORE repositories.

See the tracking issue:
https://github.com/eclipse-score/cicd-workflows/issues/75

It updates reusable workflow references from `eclipse-score/cicd-workflows`
to the pinned commit SHA (tagged as `v0.0.0`):

`c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0`

Only the `@ref` part of workflow calls is changed, for workflows under:

`eclipse-score/cicd-workflows/.github/workflows/*`

Pinning reusable workflows to a commit SHA ensures stable and reproducible CI
behavior instead of relying on a moving branch reference.

Part of eclipse-score/cicd-workflows#75
